### PR TITLE
Pin pnpm version in website deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm/action-setup looks for "packageManager" in the root package.json
+      # by default; ours lives at website/package.json, so we pin the version
+      # explicitly here.
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy website
 
 on:
   push:
-    branches: [main, zhe/fix-pnpm-setup]
+    branches: [main]
     paths:
       - 'website/**'
       - '.github/workflows/deploy.yml'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy website
 
 on:
   push:
-    branches: [main]
+    branches: [main, zhe/website]
     paths:
       - 'website/**'
       - '.github/workflows/deploy.yml'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy website
 
 on:
   push:
-    branches: [main, zhe/website]
+    branches: [main, zhe/fix-pnpm-setup]
     paths:
       - 'website/**'
       - '.github/workflows/deploy.yml'


### PR DESCRIPTION
## Summary

The first website deploy run failed with:

> Error: No pnpm version is specified.

`pnpm/action-setup@v4` defaults to reading `packageManager` from the **root** `package.json`. Our `package.json` lives at `website/package.json`, so the action couldn't find a version.

Pin `version: 10.32.1` directly in the step (matches `website/package.json`'s `packageManager` field).

## Test plan

- [ ] Merge → watch the `Deploy website` workflow succeed
- [ ] https://verina.io/ serves the React site

🤖 Generated with [Claude Code](https://claude.com/claude-code)